### PR TITLE
Update py-publish.yml to generate build provenance attestations

### DIFF
--- a/.github/workflows/py-publish.yml
+++ b/.github/workflows/py-publish.yml
@@ -5,6 +5,8 @@ on:
 
 permissions:
   contents: read
+  id-token: write
+  attestations: write
 
 jobs:
   publish-to-pypi:
@@ -28,6 +30,11 @@ jobs:
 
     - name: Check distribution
       run: twine check dist/*
+
+    - name: Create attestations
+      uses: actions/attest-build-provenance@v1
+      with:
+        subject-path: 'dist/*'
 
     - name: Publish package (to TestPyPI)
       if: github.event_name == 'workflow_dispatch' && startsWith(github.repository, 'cpp-linter')


### PR DESCRIPTION
ref to #28. update .github/workflows/py-publish.yml will allow all released Python packages in cpp-linter org can support generating attestations. then users can [verify artifact attestations with GitHub CLI](https://docs.github.com/en/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds#verifying-artifact-attestations-with-the-github-cli) if they need to. 