### PR TITLE
let sphinx.yml operate on a non-default docs  location

### DIFF
--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Upload docs build as artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ github.event.repository.name }}_docs
+          name: ${{ inputs.project-root == '.' && github.event.repository.name || inputs.project-root }}_docs
           path: ${{ github.workspace }}/${{ inputs.path-to-doc }}
 
       - name: Upload to github pages

--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -8,6 +8,11 @@ on:
         type: string
         default: docs/_build/html
         description: The docs path name
+      project-root:
+        required: false
+        type: string
+        default: '.'
+        description: The root directory of conrtaining the docs folder
 
 jobs:
   sphinx-deploy:
@@ -17,10 +22,13 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: 3.x
+
       - name: Install dependencies
+        working-directory: ${{ inputs.project-root }}
         run: pip install -r docs/requirements.txt -e .
 
       - name: Build docs
+        working-directory: ${{ inputs.project-root }}
         run: sphinx-build docs ${{ inputs.path-to-doc }}
 
       - name: Upload docs build as artifact


### PR DESCRIPTION
This allows the calling workflow to specify where the docs folder is located.

The new input, `project-root`, is optional, so this will not break any current CI workflows. If `project-root` is set to anything other than the default (`'.'`), then the artifact name uses the input value instead of the repo's name.

> [!tip]
> This is handy for a [monorepo](https://en.wikipedia.org/wiki/Monorepo) (a repo that contains multiple projects). The cpp_linter_rs repo is a [cargo workspace](https://doc.rust-lang.org/cargo/reference/workspaces.html), which is like a monorepo.