### PR TITLE
revert #30

### DIFF
--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -8,11 +8,6 @@ on:
         type: string
         default: docs/_build/html
         description: The docs path name
-      project-root:
-        required: false
-        type: string
-        default: '.'
-        description: The root directory of conrtaining the docs folder
 
 jobs:
   sphinx-deploy:
@@ -24,18 +19,16 @@ jobs:
           python-version: 3.x
 
       - name: Install dependencies
-        working-directory: ${{ inputs.project-root }}
         run: pip install -r docs/requirements.txt -e .
 
       - name: Build docs
-        working-directory: ${{ inputs.project-root }}
         run: sphinx-build docs ${{ inputs.path-to-doc }}
 
       - name: Upload docs build as artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ inputs.project-root == '.' && github.event.repository.name || inputs.project-root }}_docs
-          path: ${{ github.workspace }}/${{ inputs.project-root }}/${{ inputs.path-to-doc }}
+          name: ${{ github.event.repository.name }}_docs
+          path: ${{ github.workspace }}/${{ inputs.path-to-doc }}
 
       - name: Upload to github pages
         # only publish doc changes from main branch
@@ -43,4 +36,4 @@ jobs:
         uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./${{ inputs.project-root }}/${{ inputs.path-to-doc }}
+          publish_dir: ./${{ inputs.path-to-doc }}


### PR DESCRIPTION
reverts #30 

I can't use the reusable workflow for cpp_linter_rs because
1. the python package does not need to be built.
2. uploading artifacts cannot use `./` in the given `path`. This affects all repos except cpp_linter_rs because `project-root` input defaulted to `.`. See attempted/failed workaround in e3d904b463a5153123e666f4e6b3da3c221c3dda)

I'm going back to just doing it in the repo's CI instead. I might also switch to mkdocs for cpp_linter_rs too.