### PR TITLE
chore: switch-to-uv

### DIFF
--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -8,14 +8,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: actions/setup-python@v5
-        with:
-          python-version: 3.x
+      - uses: astral-sh/setup-uv@v6
       - name: Install dependencies
-        run: pip install -r docs/requirements.txt
-      - name: check mkdocs build
+        run: uv sync --group docs
+      - name: Check mkdocs build
         if: github.ref != 'refs/heads/main'
-        run: mkdocs build
+        run: uv run mkdocs build
       - name: Upload docs build as artifact
         if: github.ref != 'refs/heads/main'
         uses: actions/upload-artifact@v4
@@ -27,4 +25,4 @@ jobs:
         run: |
           git config user.name 'github-actions'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
-          mkdocs gh-deploy --force
+          uv run mkdocs gh-deploy --force

--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -14,15 +14,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: actions/setup-python@v5
-        with:
-          python-version: 3.x
+      - uses: astral-sh/setup-uv@v6
 
       - name: Install dependencies
-        run: pip install -r docs/requirements.txt -e .
+        run: uv sync --group docs
 
       - name: Build docs
-        run: sphinx-build docs ${{ inputs.path-to-doc }}
+        run: uv run sphinx-build docs ${{ inputs.path-to-doc }}
 
       - name: Upload docs build as artifact
         uses: actions/upload-artifact@v4

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v6.0.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer


### PR DESCRIPTION
Only applies to reusable workflows that built docs in our other repos.

I updated the pre-commit hooks too.