### PR TITLE
feat: use full commit SHA hash for dependency

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -43,11 +43,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v5
+      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@3c3833e0f8c1c83d449a7478aa59c036a9165498 #v3
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -60,7 +60,7 @@ jobs:
     # Autobuild attempts to build any compiled languages (C/C++, C#, Go, Java, or Swift).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v3
+      uses: github/codeql-action/autobuild@3c3833e0f8c1c83d449a7478aa59c036a9165498 #v3
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -74,6 +74,6 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@3c3833e0f8c1c83d449a7478aa59c036a9165498 #v3
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -7,8 +7,8 @@ jobs:
   mkdocs-deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: astral-sh/setup-uv@v6
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5
+      - uses: astral-sh/setup-uv@4959332f0f014c5280e7eac8b70c90cb574c9f9b #v6
       - name: Install dependencies
         run: uv sync --group docs
       - name: Check mkdocs build
@@ -16,7 +16,7 @@ jobs:
         run: uv run mkdocs build
       - name: Upload docs build as artifact
         if: github.ref != 'refs/heads/main'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #v4
         with:
           name: ${{ github.event.repository.name }}_docs
           path: ${{ github.workspace }}/site

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -13,8 +13,8 @@ jobs:
   run-pre-commit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 #v5
         id: python-setup
         with:
           python-version: '3.x'
@@ -22,7 +22,7 @@ jobs:
         if: inputs.commands
         run: ${{ inputs.commands }}
       - name: Cache pre-commit environments
-        uses: actions/cache@v4
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 #v4
         with:
           path: '~/.cache/pre-commit'
           key: pre-commit-${{ steps.python-setup.outputs.python-version }}-${{ hashFiles('.pre-commit-config.yaml') }}

--- a/.github/workflows/py-coverage.yml
+++ b/.github/workflows/py-coverage.yml
@@ -8,16 +8,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 #v5
         with:
           pattern: coverage-data-*
           merge-multiple: true
 
       - name: Setup python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 #v5
         with:
           python-version: '3.x'
 
@@ -28,14 +28,14 @@ jobs:
           coverage html
 
       - name: Upload comprehensive coverage HTML report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #v4
         with:
           name: coverage-report
           path: htmlcov/
 
       - run: coverage report && coverage xml
 
-      - uses: codecov/codecov-action@v5
+      - uses: codecov/codecov-action@fdcc8476540edceab3de004e990f80d881c6cc00 #v5
         env:
           CODECOV_TOKEN: ${{secrets.CODECOV_TOKEN}}
         with:

--- a/.github/workflows/py-publish.yml
+++ b/.github/workflows/py-publish.yml
@@ -13,12 +13,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5
       # use fetch --all for setuptools_scm to work
       with:
         fetch-depth: 0
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 #v5
       with:
         python-version: '3.x'
 
@@ -32,7 +32,7 @@ jobs:
       run: twine check dist/*
 
     - name: Create attestations
-      uses: actions/attest-build-provenance@v3
+      uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a #v3
       with:
         subject-path: 'dist/*'
 

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Draft your next Release notes as Pull Requests are merged into the default branch
-      - uses: release-drafter/release-drafter@v6
+      - uses: release-drafter/release-drafter@b1476f6e6eb133afa41ed8589daba6dc69b4d3f5 #v6
         with:
           commitish: '${{ inputs.commitish }}'
         env:

--- a/.github/workflows/snyk-container.yml
+++ b/.github/workflows/snyk-container.yml
@@ -7,10 +7,10 @@ jobs:
   snyk:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5
     - name: Run Snyk to check Docker image for vulnerabilities
       continue-on-error: true
-      uses: snyk/actions/docker@master
+      uses: snyk/actions/docker@b98d498629f1c368650224d6d212bf7dfa89e4bf #v0.4.0
       env:
         # In order to use the Snyk Action you will need to have a Snyk API token.
         # More details in https://github.com/snyk/actions#getting-your-snyk-token
@@ -21,6 +21,6 @@ jobs:
         args: --severity-threshold=high --file=Dockerfile.all
 
     - name: Upload result to GitHub Code Scanning
-      uses: github/codeql-action/upload-sarif@v3
+      uses: github/codeql-action/upload-sarif@3c3833e0f8c1c83d449a7478aa59c036a9165498 #v3
       with:
         sarif_file: snyk.sarif

--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -13,8 +13,8 @@ jobs:
   sphinx-deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: astral-sh/setup-uv@v6
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5
+      - uses: astral-sh/setup-uv@4959332f0f014c5280e7eac8b70c90cb574c9f9b #v6
 
       - name: Install dependencies
         run: uv sync --group docs
@@ -23,7 +23,7 @@ jobs:
         run: uv run sphinx-build docs ${{ inputs.path-to-doc }}
 
       - name: Upload docs build as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #v4
         with:
           name: ${{ github.event.repository.name }}_docs
           path: ${{ github.workspace }}/${{ inputs.path-to-doc }}
@@ -31,7 +31,7 @@ jobs:
       - name: Upload to github pages
         # only publish doc changes from main branch
         if: github.ref == 'refs/heads/main'
-        uses: peaceiris/actions-gh-pages@v4
+        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e #v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./${{ inputs.path-to-doc }}

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -6,7 +6,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 #v9
         with:
             stale-issue-message: >-
                 This issue has been automatically marked as stale because


### PR DESCRIPTION
closes #40 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pinned GitHub Actions to specific commit SHAs across CI workflows for reproducibility and supply-chain hardening; no behavior changes.
  * Updated workflows: codeql, mkdocs, pre-commit, py-coverage, py-publish, release-drafter, snyk-container, sphinx, stale.
  * Locked common actions (checkout, setup-python, setup-uv, cache, upload/download-artifact, CodeQL init/autobuild/analyze/upload-sarif, Release Drafter, Snyk Docker, gh-pages, codecov, stale) to fixed revisions while preserving existing inputs and flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->