### PR TITLE
Update dependabot.yml interval to monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,4 +8,4 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: "daily"
+      interval: "monthly"


### PR DESCRIPTION
It would be too frequent to check dependencies daily, let's update to monthly even quarterly 