### PR TITLE
Rename section for plugin developers to developers

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -26,7 +26,7 @@ categories:
   - title: 🌐 Localization and translation
     labels:
       - localization
-  - title: 👷 Changes for plugin developers
+  - title: 👷 Changes for developers
     labels:
       - developer
   - title: 📝 Documentation updates


### PR DESCRIPTION
The original config `.github/release-drafter.yml` was copied from Jenkins org for the Jenkins plugin release

https://github.com/jenkinsci/.github/blob/102bed60092be306d9736c16ba6f0d2567c10532/.github/release-drafter.yml#L42

We should remove the plugin from the section below

<img width="1004" height="419" alt="image" src="https://github.com/user-attachments/assets/9be345f4-656c-4193-acfd-1256f4d98c98" />
