### PR TITLE
add: statically analyze CI workflows

### DIFF
--- a/.github/workflows/ci-check.yml
+++ b/.github/workflows/ci-check.yml
@@ -1,0 +1,27 @@
+on:
+  workflow_call:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions: {}
+
+jobs:
+  check-ci-workflows:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
+          repository: ${{ github.repository }}
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 #v5
+        with:
+          python-version: '3.x'
+      - name: Run zizmor
+        env:
+          GH_TOKEN: ${{ github.token }}
+          FORCE_COLOR: 1
+        run: pipx run zizmor --format=github .github/workflows/*.yml

--- a/.github/workflows/ci-check.yml
+++ b/.github/workflows/ci-check.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           persist-credentials: false
           repository: ${{ github.repository }}
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 #v5
+      - uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
         with:
           python-version: '3.x'
       - name: Run zizmor

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -44,6 +44,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5
+      with:
+        persist-credentials: false
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,8 +6,16 @@ on:
   pull_request:
     branches: [main]
 
+permissions: {}
+
 jobs:
   main:
+    permissions:
+      contents: read
     uses: ./.github/workflows/pre-commit.yml
   stale:
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
     uses: ./.github/workflows/stale.yml

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -22,7 +22,9 @@ jobs:
           python-version: '3.x'
       - name: Run commands
         if: inputs.commands
-        run: ${{ inputs.commands }}
+        run: ${INPUTS_COMMANDS}
+        env:
+          INPUTS_COMMANDS: ${{ inputs.commands }}
       - name: Cache pre-commit environments
         uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
@@ -61,14 +63,16 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
       - name: conventional-commit
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
         run: >-
-          echo "${{ github.event.pull_request.title }}"
+          echo "${PR_TITLE}"
           | committed --config ${{ github.workspace }}/org-repo/.github/committed.toml --commit-file -
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: latest
       - name: spell check
         working-directory: project-repo
-        run: >-
-          echo "${{ github.event.pull_request.title }}"
-          | npx cspell-cli lint stdin
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: echo "${PR_TITLE}" | npx cspell-cli lint stdin

--- a/.github/workflows/py-coverage.yml
+++ b/.github/workflows/py-coverage.yml
@@ -8,18 +8,18 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           persist-credentials: false
 
       - name: Download all artifacts
-        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 #v5
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
         with:
           pattern: coverage-data-*
           merge-multiple: true
 
       - name: Setup python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 #v5
+        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
         with:
           python-version: '3.x'
 
@@ -30,14 +30,14 @@ jobs:
           coverage html
 
       - name: Upload comprehensive coverage HTML report
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: coverage-report
           path: htmlcov/
 
       - run: coverage report && coverage xml
 
-      - uses: codecov/codecov-action@fdcc8476540edceab3de004e990f80d881c6cc00 #v5
+      - uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7 # v5.5.1
         env:
           CODECOV_TOKEN: ${{secrets.CODECOV_TOKEN}}
         with:

--- a/.github/workflows/py-coverage.yml
+++ b/.github/workflows/py-coverage.yml
@@ -9,6 +9,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5
+        with:
+          persist-credentials: false
 
       - name: Download all artifacts
         uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 #v5

--- a/.github/workflows/py-publish.yml
+++ b/.github/workflows/py-publish.yml
@@ -13,13 +13,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5
+    - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       # use fetch --all for setuptools_scm to work
       with:
         fetch-depth: 0
         persist-credentials: false
     - name: Set up Python
-      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 #v5
+      uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
       with:
         python-version: '3.x'
 
@@ -33,7 +33,7 @@ jobs:
       run: twine check dist/*
 
     - name: Create attestations
-      uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a #v3
+      uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3.0.0
       with:
         subject-path: 'dist/*'
 

--- a/.github/workflows/py-publish.yml
+++ b/.github/workflows/py-publish.yml
@@ -17,6 +17,7 @@ jobs:
       # use fetch --all for setuptools_scm to work
       with:
         fetch-depth: 0
+        persist-credentials: false
     - name: Set up Python
       uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 #v5
       with:
@@ -37,14 +38,14 @@ jobs:
         subject-path: 'dist/*'
 
     - name: Publish package (to TestPyPI)
-      if: github.event_name == 'workflow_dispatch' && startsWith(github.repository, 'cpp-linter')
+      if: startsWith(github.repository, 'cpp-linter') && !startsWith(github.ref, 'refs/tags/')
       env:
         TWINE_USERNAME: __token__
         TWINE_PASSWORD: ${{ secrets.TEST_PYPI_TOKEN }}
       run: twine upload --repository testpypi dist/*
 
     - name: Publish package (to PyPI)
-      if: github.event_name != 'workflow_dispatch' && startsWith(github.repository, 'cpp-linter')
+      if: startsWith(github.repository, 'cpp-linter') && startsWith(github.ref, 'refs/tags/')
       env:
         TWINE_USERNAME: __token__
         TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/snyk-container.yml
+++ b/.github/workflows/snyk-container.yml
@@ -8,6 +8,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5
+      with:
+        persist-credentials: false
     - name: Run Snyk to check Docker image for vulnerabilities
       continue-on-error: true
       uses: snyk/actions/docker@b98d498629f1c368650224d6d212bf7dfa89e4bf #v0.4.0

--- a/.github/workflows/snyk-container.yml
+++ b/.github/workflows/snyk-container.yml
@@ -7,12 +7,12 @@ jobs:
   snyk:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5
+    - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       with:
         persist-credentials: false
     - name: Run Snyk to check Docker image for vulnerabilities
       continue-on-error: true
-      uses: snyk/actions/docker@b98d498629f1c368650224d6d212bf7dfa89e4bf #v0.4.0
+      uses: snyk/actions/docker@b98d498629f1c368650224d6d212bf7dfa89e4bf # v0.4.0
       env:
         # In order to use the Snyk Action you will need to have a Snyk API token.
         # More details in https://github.com/snyk/actions#getting-your-snyk-token

--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -20,7 +20,9 @@ jobs:
       - name: Install dependencies
         run: uv sync --group docs
       - name: Build docs
-        run: uv run sphinx-build docs ${{ inputs.path-to-doc }}
+        run: uv run sphinx-build docs ${INPUTS_PATH_TO_DOC}
+        env:
+          INPUTS_PATH_TO_DOC: ${{ inputs.path-to-doc }}
       - name: Upload docs build as artifact
         uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
         with:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,16 +1,20 @@
-name: 'Close stale issues'
+name: "Close stale issues"
 
 on: [workflow_call]
 
 jobs:
   stale:
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 #v9
         with:
-            stale-issue-message: >-
-                This issue has been automatically marked as stale because
-                it has not had recent activity.
-                It will be closed if no further activity occurs.
-            # Better to exclude certain issues from being marked as stale
-            exempt-issue-labels: 'help wanted,security,pinned,bug'
+          stale-issue-message: >-
+            This issue has been automatically marked as stale because
+            it has not had recent activity.
+            It will be closed if no further activity occurs.
+          # Better to exclude certain issues from being marked as stale
+          exempt-issue-labels: "help wanted,security,pinned,bug"

--- a/cspell.config.yml
+++ b/cspell.config.yml
@@ -17,6 +17,7 @@ words:
   - testpypi
   - venv
   - xianpengshen
+  - zizmor
 ignorePaths:
   - .env/**
   - .venv/**


### PR DESCRIPTION
resolves #46

- includes changes to satisfy warnings/errors raised by zizmor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CI step to automatically validate and lint GitHub workflow files.

* **Chores**
  * Enforced least-privilege permissions and disabled credential persistence for checkout in workflows.
  * Standardized passing inputs via environment variables in pre-commit and docs build.
  * Adjusted publish gating to rely on repository prefix and tag status.
  * Added a new dictionary term for spell checking and small workflow consistency/formatting updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->