### PR TITLE
fix: get PR title dynamically

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -55,25 +55,15 @@ jobs:
           persist-credentials: false
           repository: cpp-linter/.github
           path: org-repo
-      - name: Setup Nu shell
-        uses: hustcer/setup-nu@985d59ec83ae3e3418f9d36471cda38b9d8b9879 # v3.20
-        with:
-          version: ${{ vars.NUSHELL_VERSION || '*' }}
       - name: Get PR title
-        # working-directory: project-repo
-        shell: nu {0}
         id: get-title
         env:
           GH_REPO: ${{ github.repository }}
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |-
-          let pr_title = (
-            (^gh pr view $env.PR_NUMBER --repo $env.GH_REPO --json "title")
-            | from json
-            | get title
-          )
-          $"title=($pr_title)\n" | save --append $env.GITHUB_OUTPUT
+          pr_title=$(gh pr view "${PR_NUMBER}" --repo "${GH_REPO}" --json "title" -q ".title")
+          echo "title=${pr_title}" >> "${GITHUB_OUTPUT}"
       - run: rustup update --no-self-update
       - name: Install cargo-binstall
         uses: cargo-bins/cargo-binstall@2bb61346d075e720d4c3da92f23b6d612d5a7543 # v1.15.3
@@ -85,14 +75,12 @@ jobs:
         env:
           PR_TITLE: "${{ steps.get-title.outputs.title }}"
           COMMITTED_CONFIG: ${{ github.workspace }}/org-repo/.github/committed.toml
-        shell: nu {0}
-        run: $env.PR_TITLE | ^committed --config $env.COMMITTED_CONFIG --commit-file -
+        run: echo "${PR_TITLE}" | committed --config "${COMMITTED_CONFIG}" --commit-file -
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: latest
       - name: spell check
         working-directory: project-repo
-        shell: nu {0}
         env:
           PR_TITLE: "${{ steps.get-title.outputs.title }}"
-        run: $env.PR_TITLE | ^npx cspell-cli lint stdin
+        run: echo "${PR_TITLE}" | npx cspell-cli lint stdin


### PR DESCRIPTION
This should remove some confusion about checking a changed PR title

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Standardized PR title retrieval and propagation across validation checks to ensure consistent validation input.
  - Switched pipeline steps to a consistent shell environment for more reliable title processing.
  - Centralized configuration for commit-message and spell-check validations.
  - Minor workflow formatting cleanups.
  - No user-facing changes; internal CI reliability and consistency improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->