### PR TITLE
feat: update README.md to add clang-tools-wheel

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -19,7 +19,7 @@ Integrate Cpp Linter into your workflow with:
 
 ### Clang Tools — Simplified
 
-We provide ready-to-use **binaries**, **Docker images** and **Python wheels** of key `clang-tools`:
+We provide ready-to-use **binaries**, **Docker images**, and **Python wheels** of key `clang-tools`:
 
 * [clang-tools-static-binaries](https://github.com/cpp-linter/clang-tools-static-binaries)
 * [clang-tools-docker](https://github.com/cpp-linter/clang-tools-docker)


### PR DESCRIPTION
I’ve redistributed the clang-tools Python wheels to [GitHub releases](https://github.com/cpp-linter/clang-tools-wheel/releases) without making any changes upstream. The goal is to have the wheels readily available when needed, without having to wait for an upstream request—similar to what was done in https://github.com/ssciwr/clang-tidy-wheel/issues/100 and https://github.com/ssciwr/clang-tidy-wheel/pull/96

And maybe it can replace https://github.com/cpp-linter/clang-tools-static-binaries via [clang-tools CLI](https://github.com/cpp-linter/clang-tools-pip) in the future..

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Clang Tools installation instructions to include Python wheel distribution as an option for easier installs.
  * Added a direct link to the clang-tools-wheel repository for quicker access and setup.
  * Clarified and streamlined installation steps for cross-platform environments.
  * No changes to runtime behavior, public APIs, or function signatures; documentation-only changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->