### PR TITLE
fix: use org-wide release-drafter config for PR auto-labeling

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -15,3 +15,5 @@ jobs:
       - uses: release-drafter/release-drafter/autolabeler@3a7fb5c85b80b1dda66e1ccb94009adbbd32fce3 # v7.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          config-name: github:cpp-linter/.github:/.github/release-drafter.yml


### PR DESCRIPTION
This fixes an error on default `config-name` value when repo-specific config is absent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal workflow configuration.

This release contains no user-visible changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->