### PR TITLE
fix: use org-repo cspell config for spell check in check-pr-title

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -85,5 +85,10 @@ jobs:
       - name: spell check
         env:
           PR_TITLE: "${{ steps.get-title.outputs.title }}"
-          CSPELL_CONFIG: ${{ github.workspace }}/org-repo/cspell.config.yml
-        run: echo "${PR_TITLE}" | npx cspell-cli lint --config "${CSPELL_CONFIG}" stdin
+        run: |
+          if [ -f project-repo/cspell.config.yml ]; then
+            CSPELL_CONFIG="project-repo/cspell.config.yml"
+          else
+            CSPELL_CONFIG="org-repo/cspell.config.yml"
+          fi
+          echo "${PR_TITLE}" | npx cspell-cli lint --config "${CSPELL_CONFIG}" stdin

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -83,7 +83,7 @@ jobs:
         with:
           node-version: latest
       - name: spell check
-        working-directory: project-repo
         env:
           PR_TITLE: "${{ steps.get-title.outputs.title }}"
-        run: echo "${PR_TITLE}" | npx cspell-cli lint stdin
+          CSPELL_CONFIG: ${{ github.workspace }}/org-repo/cspell.config.yml
+        run: echo "${PR_TITLE}" | npx cspell-cli lint --config "${CSPELL_CONFIG}" stdin


### PR DESCRIPTION
## Problem

The `check-pr-title` job's spell check step was running with `working-directory: project-repo`, so `cspell-cli` looked for `cspell.config.yml` in the calling repo (e.g., cpp-linter-hooks). Most repos in the org don't have their own cspell config, causing false positives where words already defined in the org-repo's `cspell.config.yml` (like `setuptools`, `pyproject`) were flagged as unknown.

Fixes #76.

## Solution

Pass `--config` pointing to the org-repo's `cspell.config.yml`, matching the pattern already used by the `committed` step (which uses `--config "${COMMITTED_CONFIG}"`).

### Before
```yaml
- name: spell check
  working-directory: project-repo
  env:
    PR_TITLE: "${{ steps.get-title.outputs.title }}"
  run: echo "${PR_TITLE}" | npx cspell-cli lint stdin
```

### After
```yaml
- name: spell check
  env:
    PR_TITLE: "${{ steps.get-title.outputs.title }}"
    CSPELL_CONFIG: ${{ github.workspace }}/org-repo/cspell.config.yml
  run: echo "${PR_TITLE}" | npx cspell-cli lint --config "${CSPELL_CONFIG}" stdin
```

## CSpell supports `--config` flag

CSpell CLI has a `-c, --config` option to specify a configuration file to use, so no need to replace it with another tool.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced the spell check workflow in pull request validation to support flexible configuration file selection, improving CI/CD reliability and configuration management across projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->