### PR TITLE
feat: add Maintainers section to profile README

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -56,17 +56,22 @@ Prefer modern package managers? Install `clang-format`, `clang-tidy`, `clang-que
 
 ## 👥 Maintainers
 
-<p align="center">Meet the team behind cpp-linter:</p>
-
-<p align="center">
-  <a href="https://github.com/shenxianpeng" title="shenxianpeng">
-    <img src="https://github.com/shenxianpeng.png" width="80" alt="shenxianpeng" />
-  </a>
-  &ensp;
-  <a href="https://github.com/2bndy5" title="2bndy5">
-    <img src="https://github.com/2bndy5.png" width="80" alt="2bndy5" />
-  </a>
-</p>
+<table align="center">
+  <tr>
+    <td align="center">
+      <a href="https://github.com/shenxianpeng">
+        <img src="https://github.com/shenxianpeng.png" width="100px;" alt="shenxianpeng" /><br />
+        <sub><b>shenxianpeng</b></sub>
+      </a>
+    </td>
+    <td align="center">
+      <a href="https://github.com/2bndy5">
+        <img src="https://github.com/2bndy5.png" width="100px;" alt="2bndy5" /><br />
+        <sub><b>2bndy5</b></sub>
+      </a>
+    </td>
+  </tr>
+</table>
 
 ---
 

--- a/profile/README.md
+++ b/profile/README.md
@@ -60,14 +60,14 @@ Prefer modern package managers? Install `clang-format`, `clang-tidy`, `clang-que
   <tr>
     <td>
       <a href="https://github.com/shenxianpeng">
-        <img src="https://github.com/shenxianpeng.png" width="80" alt="shenxianpeng" /><br />
-        <sub><b>shenxianpeng</b></sub>
+        <img src="https://github.com/shenxianpeng.png" width="100" alt="shenxianpeng" /><br />
+        <b>shenxianpeng</b>
       </a>
     </td>
     <td>
       <a href="https://github.com/2bndy5">
-        <img src="https://github.com/2bndy5.png" width="80" alt="2bndy5" /><br />
-        <sub><b>2bndy5</b></sub>
+        <img src="https://github.com/2bndy5.png" width="100" alt="2bndy5" /><br />
+        <b>2bndy5</b>
       </a>
     </td>
   </tr>

--- a/profile/README.md
+++ b/profile/README.md
@@ -54,6 +54,27 @@ Prefer modern package managers? Install `clang-format`, `clang-tidy`, `clang-que
 
 ---
 
+## 👥 Maintainers
+
+<table align="center">
+  <tr>
+    <td align="center">
+      <a href="https://github.com/shenxianpeng">
+        <img src="https://github.com/shenxianpeng.png" width="100px;" alt="shenxianpeng" /><br />
+        <sub><b>shenxianpeng</b></sub>
+      </a>
+    </td>
+    <td align="center">
+      <a href="https://github.com/2bndy5">
+        <img src="https://github.com/2bndy5.png" width="100px;" alt="2bndy5" /><br />
+        <sub><b>2bndy5</b></sub>
+      </a>
+    </td>
+  </tr>
+</table>
+
+---
+
 ## 🤝 Contributing
 
 We welcome contributions of all kinds — bug reports, feature requests, documentation improvements, and code.

--- a/profile/README.md
+++ b/profile/README.md
@@ -56,22 +56,17 @@ Prefer modern package managers? Install `clang-format`, `clang-tidy`, `clang-que
 
 ## 👥 Maintainers
 
-<table align="center">
-  <tr>
-    <td align="center">
-      <a href="https://github.com/shenxianpeng">
-        <img src="https://github.com/shenxianpeng.png" width="100px;" alt="shenxianpeng" /><br />
-        <sub><b>shenxianpeng</b></sub>
-      </a>
-    </td>
-    <td align="center">
-      <a href="https://github.com/2bndy5">
-        <img src="https://github.com/2bndy5.png" width="100px;" alt="2bndy5" /><br />
-        <sub><b>2bndy5</b></sub>
-      </a>
-    </td>
-  </tr>
-</table>
+<p align="center">Meet the team behind cpp-linter:</p>
+
+<p align="center">
+  <a href="https://github.com/shenxianpeng" title="shenxianpeng">
+    <img src="https://github.com/shenxianpeng.png" width="80" alt="shenxianpeng" />
+  </a>
+  &ensp;
+  <a href="https://github.com/2bndy5" title="2bndy5">
+    <img src="https://github.com/2bndy5.png" width="80" alt="2bndy5" />
+  </a>
+</p>
 
 ---
 

--- a/profile/README.md
+++ b/profile/README.md
@@ -56,17 +56,17 @@ Prefer modern package managers? Install `clang-format`, `clang-tidy`, `clang-que
 
 ## 👥 Maintainers
 
-<table align="center">
+<table>
   <tr>
-    <td align="center">
+    <td>
       <a href="https://github.com/shenxianpeng">
-        <img src="https://github.com/shenxianpeng.png" width="100px;" alt="shenxianpeng" /><br />
+        <img src="https://github.com/shenxianpeng.png" width="80" alt="shenxianpeng" /><br />
         <sub><b>shenxianpeng</b></sub>
       </a>
     </td>
-    <td align="center">
+    <td>
       <a href="https://github.com/2bndy5">
-        <img src="https://github.com/2bndy5.png" width="100px;" alt="2bndy5" /><br />
+        <img src="https://github.com/2bndy5.png" width="80" alt="2bndy5" /><br />
         <sub><b>2bndy5</b></sub>
       </a>
     </td>


### PR DESCRIPTION
Closes #85

## Changes
- Added a 👥 **Maintainers** section to the org profile README
- Features both maintainers: @shenxianpeng and @2bndy5
- Each maintainer card links to their GitHub profile with avatar

## Preview
The section appears between the "Easy Installation" and "Contributing" sections, with centered avatar cards for each maintainer.