### PR TITLE
docs: add Homebrew tap installation method to org profile

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -53,6 +53,7 @@ Prefer modern package managers? Install `clang-format`, `clang-tidy`, `clang-que
 
 - **[pip](https://github.com/cpp-linter/clang-tools-pip)** — `pip install clang-tools` — installs static binaries or Python wheels for `clang-format`, `clang-tidy`, `clang-query`, `clang-apply-replacements`, and `clang-include-cleaner`
 - **[asdf](https://github.com/cpp-linter/asdf-clang-tools)** — `asdf plugin add clang-tools https://github.com/cpp-linter/asdf-clang-tools`
+- **[Homebrew Tap](https://github.com/cpp-linter/homebrew-tap)** — `brew tap cpp-linter/tap && brew install clang-tools` — installs pre-built static binaries for `clang-format`, `clang-tidy`, `clang-query`, `clang-apply-replacements`, and `clang-include-cleaner`
 
 ---
 


### PR DESCRIPTION
## Summary

Add the [cpp-linter Homebrew tap](https://github.com/cpp-linter/homebrew-tap) as an installation option in the organization profile README.

## Changes

- **profile/README.md** — Added a Homebrew Tap entry under the "📦 Easy Installation" section, alongside pip and asdf entries.

## Why

The Homebrew tap provides pre-built static binaries for macOS users. This makes the org profile a complete reference for all installation methods.

cc @shenxianpeng

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded package documentation with standalone entries for additional development tools
  * Introduced Homebrew Tap installation option
  * Enhanced installation instructions with comprehensive tool descriptions for package managers

<!-- end of auto-generated comment: release notes by coderabbit.ai -->