### PR TITLE
docs(profile): refresh README with a chooser table and usage example

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -20,7 +20,7 @@
 
 **cpp-linter** bundles the power of `clang-format`, `clang-tidy`, and other LLVM tools into packages that are easy to install, integrate, and maintain. Whether you’re linting a single file locally or enforcing code quality across dozens of repos in CI, cpp-linter has you covered.
 
-We target C/C++ developers and DevOps engineers who want **reliable clang tooling without the build-from-source headache**.
+We target C/C++ developers and DevOps engineers who want **reliable clang tooling without the build-from-source headache**. Our packages track the latest LLVM releases and cover Linux, macOS, and Windows on both x86_64 and Arm.
 
 ---
 
@@ -42,36 +42,53 @@ Not sure where to start? Pick the entry point that matches your workflow:
 
 ---
 
-## 🚀 Get Started
+## ⚡ Quick example
 
-Integrate cpp-linter into your workflow in minutes:
+Lint every pull request with **cpp-linter-action** — no local setup required:
 
-- **[cpp-linter-action](https://github.com/cpp-linter/cpp-linter-action)** — GitHub Action that runs `clang-format` and `clang-tidy` on PRs and pushes, posting inline annotations.
-- **[cpp-linter-hooks](https://github.com/cpp-linter/cpp-linter-hooks)** — [pre-commit](https://pre-commit.com/) hooks for local development — catch issues before they hit CI.
+```yaml
+# .github/workflows/cpp-linter.yml
+name: cpp-linter
+on: pull_request
+
+jobs:
+  cpp-linter:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cpp-linter/cpp-linter-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          style: file       # format against your .clang-format
+          tidy-checks: ''    # analyze against your .clang-tidy
+```
+
+The action posts inline annotations, a step summary, and (optionally) PR review suggestions. See the [cpp-linter-action](https://github.com/cpp-linter/cpp-linter-action) docs for all inputs and outputs.
 
 ---
 
-## 🔧 Clang Tools — Simplified
+## 📚 All projects
 
-We provide ready-to-use **binaries**, **Docker images**, and **Python wheels** of key clang tools:
+**Integrations**
 
-| Package | Description |
-|---------|-------------|
-| [clang-tools-static-binaries](https://github.com/cpp-linter/clang-tools-static-binaries) | Statically-linked `clang-format`, `clang-tidy`, `clang-query`, `clang-apply-replacements`, and `clang-include-cleaner` binaries |
-| [clang-tools-docker](https://github.com/cpp-linter/clang-tools-docker) | Docker images with pre-installed `clang-format` and `clang-tidy` |
-| [clang-tools-wheel](https://github.com/cpp-linter/clang-tools-wheel) | Redistribute `clang-format` and `clang-tidy` Python wheels |
-| [clang-apply-replacements](https://github.com/cpp-linter/clang-apply-replacements) | Standalone Python wheel for `clang-apply-replacements` |
-| [clang-include-cleaner](https://github.com/cpp-linter/clang-include-cleaner) | Standalone Python wheel for `clang-include-cleaner` — detects unused `#include` directives |
+| Project | What it does |
+|---------|--------------|
+| [cpp-linter-action](https://github.com/cpp-linter/cpp-linter-action) | GitHub Action that runs `clang-format` and `clang-tidy` on PRs and pushes, posting inline annotations, thread comments, step summaries, and PR reviews. |
+| [cpp-linter-hooks](https://github.com/cpp-linter/cpp-linter-hooks) | [pre-commit](https://pre-commit.com/) hooks that run `clang-format` and `clang-tidy` locally — catch issues before they reach CI. |
 
----
+**Clang tool distributions**
 
-## 📦 Easy Installation
-
-Prefer modern package managers? Install `clang-format`, `clang-tidy`, `clang-query`, and more via:
-
-- **[pip](https://github.com/cpp-linter/clang-tools-pip)** — `pip install clang-tools` — installs static binaries or Python wheels for `clang-format`, `clang-tidy`, `clang-query`, `clang-apply-replacements`, and `clang-include-cleaner`
-- **[asdf](https://github.com/cpp-linter/asdf-clang-tools)** — `asdf plugin add clang-tools https://github.com/cpp-linter/asdf-clang-tools`
-- **[Homebrew Tap](https://github.com/cpp-linter/homebrew-tap)** — `brew tap cpp-linter/tap && brew install clang-tools` — installs pre-built static binaries for `clang-format`, `clang-tidy`, `clang-query`, `clang-apply-replacements`, and `clang-include-cleaner`
+| Project | What it does |
+|---------|--------------|
+| [clang-tools-pip](https://github.com/cpp-linter/clang-tools-pip) | `pip install clang-tools` — cross-platform CLI that installs `clang-format`, `clang-tidy`, `clang-query`, `clang-apply-replacements`, and `clang-include-cleaner` (static binaries or Python wheels). |
+| [homebrew-tap](https://github.com/cpp-linter/homebrew-tap) | Homebrew formulae for the clang tools on macOS. |
+| [asdf-clang-tools](https://github.com/cpp-linter/asdf-clang-tools) | [asdf](https://asdf-vm.com/) plugin for version-managed installs across a team. |
+| [clang-tools-docker](https://github.com/cpp-linter/clang-tools-docker) | Docker images with `clang-format` and `clang-tidy` pre-installed for CI. |
+| [clang-tools-static-binaries](https://github.com/cpp-linter/clang-tools-static-binaries) | The upstream source: statically-linked binaries for Linux, macOS, and Windows that every other distribution builds on. |
+| [clang-tools-wheel](https://github.com/cpp-linter/clang-tools-wheel) | Python wheels that redistribute `clang-format` and `clang-tidy`. |
+| [clang-apply-replacements](https://github.com/cpp-linter/clang-apply-replacements) | Standalone Python wheel for `clang-apply-replacements`. |
+| [clang-include-cleaner](https://github.com/cpp-linter/clang-include-cleaner) | Standalone Python wheel for `clang-include-cleaner` — detects unused `#include` directives. |
 
 ---
 

--- a/profile/README.md
+++ b/profile/README.md
@@ -66,29 +66,23 @@ jobs:
 
 The action posts inline annotations, a step summary, and (optionally) PR review suggestions. See the [cpp-linter-action](https://github.com/cpp-linter/cpp-linter-action) docs for all inputs and outputs.
 
----
+<details>
+<summary>📦 <strong>More packages</strong> — lower-level & specialized builds</summary>
 
-## 📚 All projects
+<br />
 
-**Integrations**
-
-| Project | What it does |
-|---------|--------------|
-| [cpp-linter-action](https://github.com/cpp-linter/cpp-linter-action) | GitHub Action that runs `clang-format` and `clang-tidy` on PRs and pushes, posting inline annotations, thread comments, step summaries, and PR reviews. |
-| [cpp-linter-hooks](https://github.com/cpp-linter/cpp-linter-hooks) | [pre-commit](https://pre-commit.com/) hooks that run `clang-format` and `clang-tidy` locally — catch issues before they reach CI. |
-
-**Clang tool distributions**
+The tools above are built on a few underlying distributions you can also use directly:
 
 | Project | What it does |
 |---------|--------------|
-| [clang-tools-pip](https://github.com/cpp-linter/clang-tools-pip) | `pip install clang-tools` — cross-platform CLI that installs `clang-format`, `clang-tidy`, `clang-query`, `clang-apply-replacements`, and `clang-include-cleaner` (static binaries or Python wheels). |
-| [homebrew-tap](https://github.com/cpp-linter/homebrew-tap) | Homebrew formulae for the clang tools on macOS. |
-| [asdf-clang-tools](https://github.com/cpp-linter/asdf-clang-tools) | [asdf](https://asdf-vm.com/) plugin for version-managed installs across a team. |
-| [clang-tools-docker](https://github.com/cpp-linter/clang-tools-docker) | Docker images with `clang-format` and `clang-tidy` pre-installed for CI. |
 | [clang-tools-static-binaries](https://github.com/cpp-linter/clang-tools-static-binaries) | The upstream source: statically-linked binaries for Linux, macOS, and Windows that every other distribution builds on. |
 | [clang-tools-wheel](https://github.com/cpp-linter/clang-tools-wheel) | Python wheels that redistribute `clang-format` and `clang-tidy`. |
 | [clang-apply-replacements](https://github.com/cpp-linter/clang-apply-replacements) | Standalone Python wheel for `clang-apply-replacements`. |
 | [clang-include-cleaner](https://github.com/cpp-linter/clang-include-cleaner) | Standalone Python wheel for `clang-include-cleaner` — detects unused `#include` directives. |
+
+Browse every repository on the [organization page](https://github.com/cpp-linter).
+
+</details>
 
 ---
 

--- a/profile/README.md
+++ b/profile/README.md
@@ -34,7 +34,7 @@ Not sure where to start? Pick the entry point that matches your workflow:
 | Catch issues **locally before committing** | [cpp-linter-hooks](https://github.com/cpp-linter/cpp-linter-hooks) | Add to your `.pre-commit-config.yaml` |
 | Install the clang tools as a **cross-platform CLI** *(most people)* | [pip: `clang-tools`](https://github.com/cpp-linter/clang-tools-pip) | `pip install clang-tools` |
 | Install on **macOS** the native way | [Homebrew tap](https://github.com/cpp-linter/homebrew-tap) | `brew tap cpp-linter/tap && brew install clang-tools` |
-| Manage tool **versions across a polyglot team** | [asdf](https://github.com/cpp-linter/asdf-clang-tools) | `asdf plugin add clang-tools <url>` |
+| Manage tool **versions across a polyglot team** | [asdf](https://github.com/cpp-linter/asdf-clang-tools) | `asdf plugin add clang-tools https://github.com/cpp-linter/asdf-clang-tools` |
 | Run inside **containers / custom CI images** | [clang-tools-docker](https://github.com/cpp-linter/clang-tools-docker) | Pull the image |
 | Just grab the **raw static binary** | [clang-tools-static-binaries](https://github.com/cpp-linter/clang-tools-static-binaries) | Download from releases |
 

--- a/profile/README.md
+++ b/profile/README.md
@@ -24,6 +24,24 @@ We target C/C++ developers and DevOps engineers who want **reliable clang toolin
 
 ---
 
+## 🧭 Which one should I use?
+
+Not sure where to start? Pick the entry point that matches your workflow:
+
+| Your goal | Use this | How |
+|-----------|----------|-----|
+| Lint & format on **GitHub PRs / pushes** | [cpp-linter-action](https://github.com/cpp-linter/cpp-linter-action) | Add the action to your workflow |
+| Catch issues **locally before committing** | [cpp-linter-hooks](https://github.com/cpp-linter/cpp-linter-hooks) | Add to your `.pre-commit-config.yaml` |
+| Install the clang tools as a **cross-platform CLI** *(most people)* | [pip: `clang-tools`](https://github.com/cpp-linter/clang-tools-pip) | `pip install clang-tools` |
+| Install on **macOS** the native way | [Homebrew tap](https://github.com/cpp-linter/homebrew-tap) | `brew tap cpp-linter/tap && brew install clang-tools` |
+| Manage tool **versions across a polyglot team** | [asdf](https://github.com/cpp-linter/asdf-clang-tools) | `asdf plugin add clang-tools <url>` |
+| Run inside **containers / custom CI images** | [clang-tools-docker](https://github.com/cpp-linter/clang-tools-docker) | Pull the image |
+| Just grab the **raw static binary** | [clang-tools-static-binaries](https://github.com/cpp-linter/clang-tools-static-binaries) | Download from releases |
+
+> 💡 **New here?** For CI, start with **cpp-linter-action**. For local development, use **cpp-linter-hooks**. To install the underlying clang tools directly, `pip install clang-tools` works on every platform.
+
+---
+
 ## 🚀 Get Started
 
 Integrate cpp-linter into your workflow in minutes:


### PR DESCRIPTION
## Summary
Refreshes the organization profile README so the front page leads with the handful of entry points most people actually need, instead of several overlapping install sections.

## Changes
- **Added a "🧭 Which one should I use?" chooser table** — the single primary navigation, mapping a reader's goal (CI, local pre-commit, cross-platform CLI, macOS, polyglot teams, containers, raw binaries) to the right entry point and a copy-pasteable command.
- **Added a "⚡ Quick example"** with a minimal `cpp-linter-action` workflow so newcomers see it working without leaving the page.
- **Replaced the old overlapping "Get Started" / "Clang Tools" / "Easy Installation" sections** — lower-level and specialized packages (static binaries, wheels, clang-apply-replacements, clang-include-cleaner) now live in a collapsed **"More packages"** section, with a link to the full organization page.
- **Noted LLVM/platform coverage** in the About blurb (tracks latest LLVM; Linux/macOS/Windows on x86_64 and Arm).

## Notes
Scope is limited to the profile README. No changes to workflows or other repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)