### PR TITLE
chore: improve profile README About section

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -18,7 +18,7 @@
 
 ## 📖 About
 
-**cpp-linter** provides `clang-format`, `clang-tidy`, and other LLVM tools as ready-to-use packages — no building from source.
+The **cpp-linter** organization delivers **clang-format**, **clang-tidy**, and other LLVM tools as ready-to-use packages across **GitHub Actions, pre-commit hooks, CLI, Docker, and more** — no building from source.
 
 ---
 


### PR DESCRIPTION
## Summary

Updated the `About` section in `profile/README.md` to better connect the banner (which mentions workflows) with the comparison table below.

### Changes

**Before:**
> cpp-linter provides clang-format, clang-tidy, and other LLVM tools as ready-to-use packages — no building from source.

**After:**
> The cpp-linter organization delivers clang-format, clang-tidy, and other LLVM tools as ready-to-use packages across GitHub Actions, pre-commit hooks, CLI, Docker, and more — no building from source.

The new version:
- ✅ Mentions both **what** (tools) and **how** (delivery methods)
- ✅ Echoes the banner's "GitHub Actions, pre-commit hooks, and CLI"
- ✅ Foreshadows the table below (adds Docker too, since it's in the table)
- ✅ Clarifies this is the **cpp-linter organization** (not just one project)

## Related

Part of ongoing improvements to the organization profile README.
