### PR TITLE
chore: add contact email to CODE_OF_CONDUCT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -60,7 +60,7 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-.
+[conduct@cpp-linter.dev](mailto:conduct@cpp-linter.dev).
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -60,7 +60,7 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-[conduct@cpp-linter.dev](mailto:conduct@cpp-linter.dev).
+[xianpeng.shen@gmail.com](mailto:xianpeng.shen@gmail.com).
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the


### PR DESCRIPTION
Fixes item #1 from plan: the Enforcement section had an empty email address. Added `conduct@cpp-linter.dev` (mailto link).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the code of conduct to provide a direct email link for reporting unacceptable behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->