### PR TITLE
fix: guard SARIF upload with hashFiles check

### DIFF
--- a/.github/workflows/snyk-container.yml
+++ b/.github/workflows/snyk-container.yml
@@ -23,6 +23,7 @@ jobs:
         args: --severity-threshold=high --file=Dockerfile.all
 
     - name: Upload result to GitHub Code Scanning
+      if: hashFiles('snyk.sarif') != ''
       uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
       with:
         sarif_file: snyk.sarif


### PR DESCRIPTION
**Fixes item #2 from plan**

When Snyk fails (continue-on-error: true), the `snyk.sarif` file is never generated. The subsequent `upload-sarif` step would fail with 'File not found'.

Added `if: hashFiles('snyk.sarif') != ''` to skip the upload when no SARIF file exists.