### PR TITLE
feat: add input for Docker image in snyk-container workflow

### DIFF
--- a/.github/workflows/snyk-container.yml
+++ b/.github/workflows/snyk-container.yml
@@ -2,6 +2,12 @@ name: Snyk Container
 
 on:
   workflow_call:
+    inputs:
+      image:
+        description: 'Docker image to scan'
+        default: xianpengshen/clang-tools:all
+        required: false
+        type: string
 
 jobs:
   snyk:
@@ -19,7 +25,7 @@ jobs:
         # or you can sign up for free at https://snyk.io/login
         SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }} # zizmor: ignore[secrets-outside-env]
       with:
-        image: xianpengshen/clang-tools:all
+        image: ${{ inputs.image }}
         args: --severity-threshold=high --file=Dockerfile.all
 
     - name: Upload result to GitHub Code Scanning


### PR DESCRIPTION
**Fixes item #3 from plan**

The Docker image was hardcoded as `xianpengshen/clang-tools:all`, making the workflow inflexible for reuse.

Changes:
- Added `inputs.image` parameter (type: string, default: `xianpengshen/clang-tools:all`)
- Replaced hardcoded `image` with `${{ inputs.image }}`

Callers can now override the image: 
```yaml
jobs:
  snyk:
    uses: cpp-linter/.github/.github/workflows/snyk-container.yml@main
    with:
      image: my-custom-image:latest
```