### PR TITLE
chore: explicitly set days-before-stale and days-before-close

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899 #v10.3.0
         with:
+          days-before-stale: 60
+          days-before-close: 7
           stale-issue-message: >-
             This issue has been automatically marked as stale because
             it has not had recent activity.


### PR DESCRIPTION
**Fixes item #4 from plan**

The stale action was relying on GitHub's implicit defaults (60 days stale, 7 days close). Added explicit declarations for clarity and maintainability.