### PR TITLE
chore: set explicit maxkb for check-added-large-files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,7 @@ repos:
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: check-added-large-files
+        args: ["--maxkb=1024"]
       - id: check-yaml
       - id: mixed-line-ending
         args: ["--fix=lf"]


### PR DESCRIPTION
**Fixes item #7 from plan**

`check-added-large-files` was using the default 500KB limit. The branding directory contains image assets (logo, banner, etc.) that may exceed this. Set `--maxkb=1024` (1MB) to accommodate them.