### PR TITLE
feat: add issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,32 @@
+---
+name: Bug Report
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Run command '...'
+2. With arguments '...'
+3. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots / Logs**
+If applicable, add screenshots or relevant log output to help explain your problem.
+
+**Environment (please complete the following information):**
+- OS: [e.g. Ubuntu 22.04, macOS 14]
+- cpp-linter version: [e.g. 2.0.0]
+- Python version: [e.g. 3.11]
+- Git version: [e.g. 2.40]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,6 @@
 ---
 name: Bug Report
-about: Create a report to help us improve
+about: Report a bug to help us improve
 title: ''
 labels: bug
 assignees: ''
@@ -11,22 +11,15 @@ assignees: ''
 A clear and concise description of what the bug is.
 
 **To Reproduce**
-Steps to reproduce the behavior:
-1. Run command '...'
-2. With arguments '...'
-3. See error
+Steps to reproduce the behavior.
 
 **Expected behavior**
-A clear and concise description of what you expected to happen.
+What you expected to happen instead.
 
-**Screenshots / Logs**
-If applicable, add screenshots or relevant log output to help explain your problem.
-
-**Environment (please complete the following information):**
-- OS: [e.g. Ubuntu 22.04, macOS 14]
-- cpp-linter version: [e.g. 2.0.0]
-- Python version: [e.g. 3.11]
-- Git version: [e.g. 2.40]
+**Environment**
+- OS:
+- Project version:
+- Relevant tool/CLI version:
 
 **Additional context**
-Add any other context about the problem here.
+Add any other context, logs, or screenshots.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -7,21 +7,14 @@ assignees: ''
 
 ---
 
-**Is your feature request related to a problem? Please describe.**
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+**Problem**
+What problem does this solve?
 
-**Describe the solution you'd like**
-A clear and concise description of what you want to happen.
+**Solution**
+What would you like to happen?
 
-**Describe alternatives you've considered**
-A clear and concise description of any alternative solutions or features you've considered.
-
-**Usage example**
-If applicable, show how this feature would be used:
-
-```yaml
-# Example configuration or command
-```
+**Alternatives**
+Any alternative solutions you've considered.
 
 **Additional context**
-Add any other context or screenshots about the feature request here.
+Add any other context or examples.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,27 @@
+---
+name: Feature Request
+about: Suggest an idea for this project
+title: ''
+labels: enhancement
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Usage example**
+If applicable, show how this feature would be used:
+
+```yaml
+# Example configuration or command
+```
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,27 @@
+## Summary
+
+<!-- A clear and concise description of the changes. -->
+
+## Related Issues
+
+<!-- Link any related issues using "Closes #123" or "Relates to #123". -->
+
+## Type of Change
+
+- [ ] Bug fix (non-breaking change that fixes an issue)
+- [ ] New feature (non-breaking change that adds functionality)
+- [ ] Breaking change (fix or feature that would break existing functionality)
+- [ ] Documentation update
+- [ ] Chore (refactor, dependency updates, CI config, etc.)
+
+## Checklist
+
+- [ ] I have read the [contributing guidelines](https://github.com/cpp-linter/.github/blob/main/CONTRIBUTING.md) (if applicable)
+- [ ] My changes follow the project's coding style
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] New and existing tests pass locally
+- [ ] I have updated the documentation accordingly
+
+## Additional Context
+
+<!-- Any extra details, screenshots, or design decisions. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,27 +1,7 @@
 ## Summary
 
-<!-- A clear and concise description of the changes. -->
+<!-- Briefly describe what this PR does. -->
 
 ## Related Issues
 
-<!-- Link any related issues using "Closes #123" or "Relates to #123". -->
-
-## Type of Change
-
-- [ ] Bug fix (non-breaking change that fixes an issue)
-- [ ] New feature (non-breaking change that adds functionality)
-- [ ] Breaking change (fix or feature that would break existing functionality)
-- [ ] Documentation update
-- [ ] Chore (refactor, dependency updates, CI config, etc.)
-
-## Checklist
-
-- [ ] I have read the [contributing guidelines](https://github.com/cpp-linter/.github/blob/main/CONTRIBUTING.md) (if applicable)
-- [ ] My changes follow the project's coding style
-- [ ] I have added tests that prove my fix is effective or that my feature works
-- [ ] New and existing tests pass locally
-- [ ] I have updated the documentation accordingly
-
-## Additional Context
-
-<!-- Any extra details, screenshots, or design decisions. -->
+<!-- Closes #123 or Relates to #123 -->


### PR DESCRIPTION
**Fixes item #8 from plan**

Adds org-wide default issue and PR templates for all cpp-linter repositories:

- **`bug_report.md`** — structured template for bug reports (environment info, reproduction steps)
- **`feature_request.md`** — template for feature suggestions (problem, solution, alternatives)
- **`PULL_REQUEST_TEMPLATE.md`** — PR checklist (summary, related issues, change type, checklist)

These serve as defaults for any repo in the `cpp-linter` org that doesn't define its own templates.