### PR TITLE
chore: add SECURITY.md and SUPPORT.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,15 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability, please **do not** open a public
+issue. Instead, report it privately via
+[GitHub's private vulnerability reporting](https://github.com/cpp-linter/REPO/security/advisories/new)
+on the affected repository (replace `REPO` with the actual repository name).
+
+We'll respond as quickly as possible and keep you updated throughout the
+process.
+
+## Supported Versions
+
+Only the latest release of each project receives security patches.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,21 @@
+# Support
+
+## Documentation
+
+- [Main documentation](https://cpp-linter.github.io/cpp-linter)
+- Each repository may have additional documentation in its `README.md`.
+
+## Issues
+
+For bug reports and feature requests, use the
+[GitHub Issues](https://github.com/cpp-linter/REPO/issues) on the
+relevant repository (replace `REPO` with the actual repository name).
+
+## Discussions
+
+For questions, ideas, and general discussion, visit our
+[GitHub Discussions](https://github.com/cpp-linter/cpp-linter/discussions).
+
+## Security
+
+See [SECURITY.md](SECURITY.md) for reporting vulnerabilities.


### PR DESCRIPTION
**Fixes item #9 from plan**

Adds two org-wide default documents:

**SECURITY.md** — Security vulnerability reporting policy using GitHub's private vulnerability reporting.

**SUPPORT.md** — Support channels: documentation site, GitHub Issues per repo, and org-level GitHub Discussions.

These will be automatically displayed on any cpp-linter repo that doesn't have its own.