### PR TITLE
chore: add org-level CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,41 @@
+# Contributing
+
+Thank you for investing your time in contributing to a cpp-linter project!
+
+## Getting Started
+
+1. **Choose a repo** — Browse our [repositories](https://github.com/orgs/cpp-linter/repositories) and find the one you'd like to contribute to.
+2. **Read its CONTRIBUTING.md** — Each repo may have its own contribution guide with project-specific instructions.
+3. **Check open issues** — Look for issues labeled `help wanted` or `good first issue`.
+
+## General Guidelines
+
+- **Branch**: All PRs should target the `main` branch.
+- **Changelog**: If the project uses a changelog, add an entry describing your change.
+- **Tests**: Add tests for new features and bug fixes where applicable.
+- **Documentation**: Update docs if your change affects user-facing behavior.
+
+## Commit Style
+
+We recommend using [Conventional Commits](https://www.conventionalcommits.org/):
+
+- `feat:` — new feature
+- `fix:` — bug fix
+- `chore:` — maintenance, config, dependencies
+- `docs:` — documentation only
+- `refactor:` — code restructuring without feature or fix
+
+## Pull Request Process
+
+1. Fork the repository and create a feature branch.
+2. Make your changes, keeping them focused and granular.
+3. Push your branch and open a PR against `main`.
+4. Keep PRs small — separate unrelated changes into different PRs.
+
+## Code of Conduct
+
+All contributions are subject to our [Code of Conduct](CODE_OF_CONDUCT.md).
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the same license as the project you're contributing to.


### PR DESCRIPTION
**Fixes item #10 from plan**

Adds a lightweight org-wide contributing guide that covers:

- Getting started (which repo, read its CONTRIBUTING.md, check issues)
- General guidelines (branch target, changelog, tests, docs)
- Commit style (Conventional Commits)
- Pull request process (fork, small PRs, target main)
- Links to CODE_OF_CONDUCT.md

Per-repo guides take precedence for project-specific details.