### PR TITLE
fix: restrict TestPyPI publish to main branch only

### DIFF
--- a/.github/workflows/py-publish.yml
+++ b/.github/workflows/py-publish.yml
@@ -38,7 +38,7 @@ jobs:
         subject-path: 'dist/*'
 
     - name: Publish package (to TestPyPI)
-      if: startsWith(github.repository, 'cpp-linter') && !startsWith(github.ref, 'refs/tags/')
+      if: startsWith(github.repository, 'cpp-linter') && !startsWith(github.ref, 'refs/tags/') && github.ref == 'refs/heads/main'
       env:
         TWINE_USERNAME: __token__
         TWINE_PASSWORD: ${{ secrets.TEST_PYPI_TOKEN }} # zizmor: ignore[secrets-outside-env]


### PR DESCRIPTION
**Fixes item #11 from plan**

The TestPyPI publish step ran on every non-tag push (including PR merges to any branch), generating garbage versions.

Added `github.ref == 'refs/heads/main'` to restrict TestPyPI publishes to pushes on `main` only.

**Before:** `!startsWith(github.ref, 'refs/tags/')` — every non-tag push
**After:** `!startsWith(github.ref, 'refs/tags/') && github.ref == 'refs/heads/main'` — main branch pushes only

This is the last item in the plan 🎉