### PR TITLE
feat: Add funding configuration for Open Collective

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+open_collective: cpp-linter

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
+    branches: [main]
     types:
       - opened
       - reopened

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,11 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - edited # for PR title changes
 
 permissions: {}
 


### PR DESCRIPTION
I have set up https://opencollective.com/cpp-linter and invited @2bndy5 to join. This will allow the cpp-linter team to be represented as a whole and provide a way for the community to support the project. I don't expect we'll receive much financial support, but having the option available is better than having nothing at all.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added Open Collective funding information.
  * Updated pull request automation to run on additional pull request edits (including title changes).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->